### PR TITLE
Add Arcadia Finance MCP Server to DeFi & Swaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ A curated list of **MCP servers** and **AI skills** for finance, trading, and cr
 |------|-------------|---------|-------|
 | [PancakeSwap PoolSpy MCP](https://github.com/kukapay/pancakeswap-poolspy-mcp) | Track new liquidity pools | Free | ![GitHub stars](https://img.shields.io/github/stars/kukapay/pancakeswap-poolspy-mcp?style=flat) |
 | [Free USDC Transfer MCP](https://github.com/magnetai/mcp-free-usdc-transfer) | Send USDC on Base for free | Free (x402) | ![GitHub stars](https://img.shields.io/github/stars/magnetai/mcp-free-usdc-transfer?style=flat) |
+| [Arcadia Finance MCP](https://github.com/arcadia-finance/mcp-server) | Uniswap & Aerodrome liquidity positions with leverage, rebalancing, yield optimization | Free | ![GitHub stars](https://img.shields.io/github/stars/arcadia-finance/mcp-server?style=flat) |
 
 ---
 


### PR DESCRIPTION
Adding [arcadia-finance/mcp-server](https://github.com/arcadia-finance/mcp-server) to the DeFi & Swaps section.

Manage Uniswap and Aerodrome liquidity positions with leverage, automated rebalancing, and yield optimization on Base and Unichain.