### PR TITLE
feat: add pact-mcp-server — trustless escrow and payment channels for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ A curated list of **MCP servers** and **AI skills** for finance, trading, and cr
 | [Ramp MCP](https://github.com/ramp-public/ramp_mcp) | Spend analytics via LLMs | Requires credentials | ![GitHub stars](https://img.shields.io/github/stars/ramp-public/ramp_mcp?style=flat) |
 | [Fewsats MCP](https://github.com/Fewsats/fewsats-mcp) | Bitcoin purchases for AI agents | Freemium | ![GitHub stars](https://img.shields.io/github/stars/Fewsats/fewsats-mcp?style=flat) |
 | [x402 Payment MCP](https://github.com/coinbase/x402) | HTTP-native payments for AI agents | Free (x402) | ![GitHub stars](https://img.shields.io/github/stars/coinbase/x402?style=flat) |
+| [pact-mcp-server](https://github.com/praxisagent/pact-vibekit-plugin) | Trustless on-chain escrow and payment channels for AI agents on Arbitrum (ERC-8183) | Free | ![GitHub stars](https://img.shields.io/github/stars/praxisagent/pact-vibekit-plugin?style=flat) |
 
 ---
 
@@ -229,3 +230,4 @@ BlockRun enables AI agents to make autonomous payments using x402 protocol. No A
 [![CC0](https://licensebuttons.net/p/zero/1.0/88x31.png)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 To the extent possible under law, [BlockRun](https://blockrun.ai) has waived all copyright and related rights to this work.
+


### PR DESCRIPTION
## Summary

Adding **pact-mcp-server** to the Payments & Banking section.

**What it does:** Trustless on-chain escrow and payment channels for AI agents on Arbitrum One. Exposes PactEscrow v2 (ERC-8183 aligned) and PactPaymentChannel via 13 MCP tools — agents can lock funds in escrow, submit work, and settle payments trustlessly without any intermediary.

**Why it belongs here:**
- Escrow/trust layer that complements payment rails like x402 (x402 handles routing, PACT handles trust guarantees)
- Published on npm: `pact-mcp-server@1.0.1`
- Live on Arbitrum One mainnet, contracts verified on Arbiscan
- ERC-8183 (Agentic Commerce standard) aligned — same standard co-authored by Virtuals Protocol and Ethereum Foundation dAI
- First MCP server providing cryptographic escrow enforcement for agent-to-agent commerce

**Links:**
- GitHub: https://github.com/praxisagent/pact-vibekit-plugin
- npm: https://www.npmjs.com/package/pact-mcp-server
- PactEscrow v2: `0x220B97972d6028Acd70221890771E275e7734BFB` on Arbitrum One
- PactPaymentChannel: `0x5a9D124c05B425CD90613326577E03B3eBd1F891` on Arbitrum One