### PR TITLE
Add CardZero MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ A curated list of **MCP servers** and **AI skills** for finance, trading, and cr
 | [Ramp MCP](https://github.com/ramp-public/ramp_mcp) | Spend analytics via LLMs | Requires credentials | ![GitHub stars](https://img.shields.io/github/stars/ramp-public/ramp_mcp?style=flat) |
 | [Fewsats MCP](https://github.com/Fewsats/fewsats-mcp) | Bitcoin purchases for AI agents | Freemium | ![GitHub stars](https://img.shields.io/github/stars/Fewsats/fewsats-mcp?style=flat) |
 | [x402 Payment MCP](https://github.com/coinbase/x402) | HTTP-native payments for AI agents | Free (x402) | ![GitHub stars](https://img.shields.io/github/stars/coinbase/x402?style=flat) |
+| [CardZero MCP](https://github.com/mrocker/cardzero-mcp) | Smart-contract wallet for AI agents on Base (USDC) | Free (2% per tx) | ![GitHub stars](https://img.shields.io/github/stars/mrocker/cardzero-mcp?style=flat) |
 
 ---
 


### PR DESCRIPTION
Adds [`cardzero-mcp`](https://github.com/mrocker/cardzero-mcp) to the **Payments & Banking** section, alongside Stripe / Qonto / Fewsats / x402.

**What it is:** Smart-contract wallet for AI agents on Base mainnet, USDC-denominated. Owner sets spending rules in a dashboard (per-tx limit, daily cap, address whitelist, freeze) and the agent transacts autonomously within them. Buyer-side x402 support is built in.

**MCP surface:** 10 tools covering wallet creation, balance, payments (direct + x402), and ERC-8183 escrow Jobs.

**Following CONTRIBUTING.md:**
- ✅ Finance-related: agent-payment infrastructure
- ✅ Working repo: https://github.com/mrocker/cardzero-mcp (MIT, root Dockerfile, Glama Quality A)
- ✅ Real MCP server: published as [`cardzero-mcp`](https://www.npmjs.com/package/cardzero-mcp) on npm
- ✅ Functional: live in production at [cardzero.ai](https://cardzero.ai) since 2026-03; also listed on Glama at https://glama.ai/mcp/servers/mrocker/cardzero-mcp

Pricing label: `Free (2% per tx)` — using the `Free` base, since spawning a wallet and querying are free; only payment execution carries the 2% platform fee. Happy to relabel if maintainers prefer a different label.