### PR TITLE
Add ai-investment-skills to Skills section

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Skills are **task-level workflows** built on top of MCP servers or external APIs
 | [Trading Skills](https://github.com/tradermonty/claude-trading-skills) | IBD-style RS Rating for identifying stocks with strong momentum | Claude Code Skill | ![GitHub stars](https://img.shields.io/github/stars/tradermonty/claude-trading-skills?style=flat) |
 | [Invoice Organizer](https://github.com/ComposioHQ/awesome-claude-skills/tree/main/invoice-organizer) | Organize invoices and receipts for tax prep - extract, rename, sort | Claude Code Skill | - |
 | [Twitter Intel](https://github.com/BlockRunAI/blockrun-agent-wallet/tree/main/skills/twitter-intel) | Real-time X/Twitter intelligence for finance - monitor, summarize, alerts | Grok + BlockRun | ~$0.25-0.50/query |
+| [ai-investment-skills](https://github.com/tellmefrankie/ai-investment-skills) | Options flow scanner with lottery-call filter (delta <0.15), stop-loss monitor, earnings risk check, sector rotation signal. CEG raw P/C 1.06 → adjusted 59.2 after filter. Free tier: 3 tickers. | Claude Code Skill | Free (basic) / $29 (full) |
 
 ### Adding a Skill
 


### PR DESCRIPTION
## What this adds

Adds [ai-investment-skills](https://github.com/tellmefrankie/ai-investment-skills) to the **Skills** section — a Claude Code skill set for individual investors.

## Key differentiator: lottery-call filtering

Most options data is noisy because it includes "lottery calls" — deep OTM options (delta <0.15, premium <$0.10) that retail traders buy for pennies. Including these distorts the put/call ratio.

The scanner strips them before computing P/C. Real example:
- CEG (Constellation Energy): raw P/C = 1.06 (neutral) → adjusted P/C = **59.2** (extremely bearish)
- 98.2% of call volume was lottery tickets

CEG dropped 8% in the next 5 sessions.

## Skills included

- Options flow scanner with lottery-call filter (free: 3 tickers)
- Stop-loss & take-profit monitor with Telegram alerts
- Earnings risk check (IV crush detection)
- Sector rotation signal (XLI, XLF, XLE, XLK ETF P/C flow)
- Real-vs-lottery position classifier
- Daily portfolio briefing

## Install

```bash
cp options-flow-analyzer/SKILL.md ~/.claude/skills/options-flow-analyzer.md
```

Free tier included in the repo.