### PR TITLE
feat: add The Stall to Financial Intelligence — 201 pay-per-call x402 AI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ A curated list of **MCP servers** and **AI skills** for finance, trading, and cr
 | [TrendRadar](https://github.com/sansan0/TrendRadar) | AI sentiment monitoring, hot topic tracking | Free | ![GitHub stars](https://img.shields.io/github/stars/sansan0/TrendRadar?style=flat) |
 | [Finbrain MCP](https://github.com/ahmetsbilgin/finbrain-mcp) | Institutional-grade alternative data | Requires API key | ![GitHub stars](https://img.shields.io/github/stars/ahmetsbilgin/finbrain-mcp?style=flat) |
 | [Norman Finance MCP](https://github.com/norman-finance/norman-mcp-server) | Accounting, invoices, taxes | Requires credentials | ![GitHub stars](https://img.shields.io/github/stars/norman-finance/norman-mcp-server?style=flat) |
-| [The Stall](https://the-stall.intuitek.ai/mcp) | 172 pay-per-call tools: equities, crypto, DeFi, macro, on-chain, options, alternative data — x402 USDC micropayments | Sub-cent per call (no API key) | — |
+| [The Stall](https://the-stall.intuitek.ai/mcp) | 183 pay-per-call tools: equities, crypto, DeFi, macro, on-chain, options, alternative data — x402 USDC micropayments | Sub-cent per call (no API key) | — |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ A curated list of **MCP servers** and **AI skills** for finance, trading, and cr
 | [TrendRadar](https://github.com/sansan0/TrendRadar) | AI sentiment monitoring, hot topic tracking | Free | ![GitHub stars](https://img.shields.io/github/stars/sansan0/TrendRadar?style=flat) |
 | [Finbrain MCP](https://github.com/ahmetsbilgin/finbrain-mcp) | Institutional-grade alternative data | Requires API key | ![GitHub stars](https://img.shields.io/github/stars/ahmetsbilgin/finbrain-mcp?style=flat) |
 | [Norman Finance MCP](https://github.com/norman-finance/norman-mcp-server) | Accounting, invoices, taxes | Requires credentials | ![GitHub stars](https://img.shields.io/github/stars/norman-finance/norman-mcp-server?style=flat) |
+| [The Stall](https://the-stall.intuitek.ai/mcp) | 172 pay-per-call tools: equities, crypto, DeFi, macro, on-chain, options, alternative data — x402 USDC micropayments | Sub-cent per call (no API key) | — |
 
 ---
 


### PR DESCRIPTION
## The Stall

Adds **The Stall** to the Financial Intelligence section — a remote MCP server with 201 pay-per-call financial intelligence capabilities across 20+ data verticals.

### Coverage
- **Equities:** stock price, fundamentals, earnings surprises, analyst ratings, insider trades, options chain, short volume
- **Crypto/DeFi:** prices, DEX swap quotes, whale radar, protocol revenue, stablecoin watch, fear & greed, staking yields
- **Macro:** FOMC tracker, treasury yields & auctions, IMF outlook, PMI, labor market, housing brief, economic calendar
- **On-chain:** EVM logs, wallet balance, ERC20 snapshot, token security, ENS lookup, gas estimates
- **Alternative data:** congressional trades, FEC donor intel, sanctions screening (OFAC), Polymarket accuracy, NPI lookup
- 201 tools total across 20+ verticals

### What makes it unique
- **x402 protocol:** USDC micropayments on Base — no API key, no subscription, pay per call
- **No API key required:** agents pay with crypto wallets directly
- **Sub-cent pricing:** e.g., `us-stock-price` $0.018, `options-chain` $0.010, `whale-radar` $0.005
- **Remote MCP:** zero install — paste URL into any MCP client

### Connect
```
https://the-stall.intuitek.ai/mcp
```
