### PR TITLE
feat: add The Stall — 210 pay-per-call x402 financial intelligence MCP (v4.64.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ A curated list of **MCP servers** and **AI skills** for finance, trading, and cr
 
 | Name | Description | Pricing | Stars |
 |------|-------------|---------|-------|
-| [The Stall](https://the-stall.intuitek.ai) | 201 pay-per-call x402 MCP capabilities: stocks, options, DeFi yields, macro indicators, crypto, blockchain analytics, wallet intelligence | Pay-per-call (x402, USDC) | N/A |
+| [The Stall](https://the-stall.intuitek.ai) | 207 pay-per-call x402 MCP capabilities across stocks, options, DeFi, crypto, macro intelligence, and dealer GEX analysis (v4.62.0) | Pay-per-call (x402, USDC) | N/A |
 | [OpenBB Platform](https://github.com/OpenBB-finance/OpenBB) | Comprehensive financial data platform | Free + Paid | ![GitHub stars](https://img.shields.io/github/stars/OpenBB-finance/OpenBB?style=flat) |
 | [TrendRadar](https://github.com/sansan0/TrendRadar) | AI sentiment monitoring, hot topic tracking | Free | ![GitHub stars](https://img.shields.io/github/stars/sansan0/TrendRadar?style=flat) |
 | [Finbrain MCP](https://github.com/ahmetsbilgin/finbrain-mcp) | Institutional-grade alternative data | Requires API key | ![GitHub stars](https://img.shields.io/github/stars/ahmetsbilgin/finbrain-mcp?style=flat) |

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ A curated list of **MCP servers** and **AI skills** for finance, trading, and cr
 
 | Name | Description | Pricing | Stars |
 |------|-------------|---------|-------|
+| [The Stall](https://the-stall.intuitek.ai) | 201 pay-per-call x402 MCP capabilities: stocks, options, DeFi yields, macro indicators, crypto, blockchain analytics, wallet intelligence | Pay-per-call (x402, USDC) | N/A |
 | [OpenBB Platform](https://github.com/OpenBB-finance/OpenBB) | Comprehensive financial data platform | Free + Paid | ![GitHub stars](https://img.shields.io/github/stars/OpenBB-finance/OpenBB?style=flat) |
 | [TrendRadar](https://github.com/sansan0/TrendRadar) | AI sentiment monitoring, hot topic tracking | Free | ![GitHub stars](https://img.shields.io/github/stars/sansan0/TrendRadar?style=flat) |
 | [Finbrain MCP](https://github.com/ahmetsbilgin/finbrain-mcp) | Institutional-grade alternative data | Requires API key | ![GitHub stars](https://img.shields.io/github/stars/ahmetsbilgin/finbrain-mcp?style=flat) |

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ A curated list of **MCP servers** and **AI skills** for finance, trading, and cr
 
 | Name | Description | Pricing | Stars |
 |------|-------------|---------|-------|
-| [The Stall](https://the-stall.intuitek.ai) | 207 pay-per-call x402 MCP capabilities across stocks, options, DeFi, crypto, macro intelligence, and dealer GEX analysis (v4.62.0) | Pay-per-call (x402, USDC) | N/A |
+| [The Stall](https://github.com/thebrierfox/the-stall) | 208 pay-per-call AI capabilities: finance, crypto/DeFi, trading, prediction markets, weather, aviation, research. USDC micropayments via x402 on Base — no API keys | Pay-per-use (x402) | ![GitHub stars](https://img.shields.io/github/stars/thebrierfox/the-stall?style=flat) |
 | [OpenBB Platform](https://github.com/OpenBB-finance/OpenBB) | Comprehensive financial data platform | Free + Paid | ![GitHub stars](https://img.shields.io/github/stars/OpenBB-finance/OpenBB?style=flat) |
 | [TrendRadar](https://github.com/sansan0/TrendRadar) | AI sentiment monitoring, hot topic tracking | Free | ![GitHub stars](https://img.shields.io/github/stars/sansan0/TrendRadar?style=flat) |
 | [Finbrain MCP](https://github.com/ahmetsbilgin/finbrain-mcp) | Institutional-grade alternative data | Requires API key | ![GitHub stars](https://img.shields.io/github/stars/ahmetsbilgin/finbrain-mcp?style=flat) |


### PR DESCRIPTION
Add [The Stall](https://github.com/thebrierfox/the-stall) to the Financial Intelligence section — a pay-per-call x402 MCP server with **210 capabilities** across finance, crypto/DeFi, trading, prediction markets, weather, aviation, and research data. No API keys required — agents pay USDC micropayments via x402 on Base.

## What is The Stall?

The Stall is a remote MCP server providing 208 AI-callable capabilities via x402 micropayments:

- **Finance & markets**: stock prices, analyst ratings, FRED macro data, options chains, yield curves
- **Crypto & DeFi**: token prices, on-chain analytics, address security, ENS lookup, EVM token security
- **Prediction markets**: Polymarket, Kalshi market data and probabilities
- **Research & intelligence**: arXiv papers, PubMed, Reddit sentiment, news intelligence
- **Weather & aviation**: real-time weather, METAR, aviation weather
- **Utilities**: DNS lookup, NPI lookup, npm/PyPI package info

Remote endpoint: `https://the-stall.intuitek.ai/mcp`  
GitHub: https://github.com/thebrierfox/the-stall  
Version: v4.64.0 (210 capabilities)

Agents pay per call using USDC on Base via the x402 protocol — no API key management, no subscriptions.
