### PR TITLE
Add FilingFirehose MCP to Financial Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ A curated list of **MCP servers** and **AI skills** for finance, trading, and cr
 | [TrendRadar](https://github.com/sansan0/TrendRadar) | AI sentiment monitoring, hot topic tracking | Free | ![GitHub stars](https://img.shields.io/github/stars/sansan0/TrendRadar?style=flat) |
 | [Finbrain MCP](https://github.com/ahmetsbilgin/finbrain-mcp) | Institutional-grade alternative data | Requires API key | ![GitHub stars](https://img.shields.io/github/stars/ahmetsbilgin/finbrain-mcp?style=flat) |
 | [Norman Finance MCP](https://github.com/norman-finance/norman-mcp-server) | Accounting, invoices, taxes | Requires credentials | ![GitHub stars](https://img.shields.io/github/stars/norman-finance/norman-mcp-server?style=flat) |
+| [FilingFirehose MCP](https://filingfirehose.com/mcp) | SEC filing intelligence: body-text-classified 8-Ks (flags buried Item 1.05/5.02 events), Schedule 13D/G activist tagging, S-3/424B5 ATM detection, per-ticker forensic risk score (cyber/dilution/restatement/officer-departure/bankruptcy). Hosted at `https://mcp.filingfirehose.com`, no API key for 72h tier | Free + Paid | N/A (hosted) |
 
 ---
 


### PR DESCRIPTION
Adding FilingFirehose hosted MCP server to Financial Intelligence section.

What it provides:
- SEC EDGAR filing intelligence MCP for AI agents
- Body-text-classified 8-Ks flagging buried events — about 7.3% of Item 8.01 filings have buried 1.05/5.02 events the filer chose not to flag
- Schedule 13D/G with 21+ activist filers auto-tagged
- S-3/424B5 with ATM offering detection
- Per-ticker forensic risk score (LOW/MODERATE/ELEVATED/HIGH) covering cyber, dilution, restatement, officer departures, bankruptcy proximity
- Hosted remote MCP at https://mcp.filingfirehose.com
- Free 72h public tier, no API key required
- Paid plans from $9/mo

Also available as REST API, ChatGPT GPT, Python SDK (github.com/jaablon/filingfirehose-python), and GitHub Action.