### PR TITLE
Add BankBridge to Personal Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ A curated list of **MCP servers** and **AI skills** for finance, trading, and cr
 
 | Name | Description | Pricing | Stars |
 |------|-------------|---------|-------|
+| [BankBridge](https://github.com/bankbridge-money/bankbridge-plugin) | Read-only bank access for AI agents. 12 tools: balances, transactions, recurring charges, cashflow, holdings. Live-fetch via Plaid. | $5/mo per bank | ![GitHub stars](https://img.shields.io/github/stars/bankbridge-money/bankbridge-plugin?style=flat) |
 | [LunchMoney MCP](https://github.com/akutishevsky/lunchmoney-mcp) | Transaction tracking, budgeting | Requires account | ![GitHub stars](https://img.shields.io/github/stars/akutishevsky/lunchmoney-mcp?style=flat) |
 | [Monarch Money MCP](https://github.com/carsol/monarch-mcp-server) | Accounts, budgets, cashflow analysis | Requires account | ![GitHub stars](https://img.shields.io/github/stars/carsol/monarch-mcp-server?style=flat) |
 


### PR DESCRIPTION
Adds BankBridge to the Personal Finance section.

**BankBridge** is a hosted MCP server giving AI agents read-only access to bank accounts, transactions, and investment holdings via a secure bank link flow. 12 tools covering balances, transactions, recurring charges, monthly cashflow, merchant history, categories, and investment holdings/transactions. Works with Claude, ChatGPT, Cursor, Gemini, Codex, and 24 other MCP hosts.

- Site: https://bankbridge.money
- Plugin repo: https://github.com/bankbridge-money/bankbridge-plugin
- MCP endpoint: \`https://bankbridge.money/api/mcp\` (streamable-http, MCP 2025-06-18)
- Auth: Bearer (\`bbk_...\`) or OAuth 2.1 with DCR + PKCE
- Pricing: \$5/month per connected bank, first month free
- Already listed on the official MCP Registry as \`money.bankbridge/server\`

Inserted alphabetically before LunchMoney. Happy to tweak description length, pricing column wording, or row position if anything's off.
