### PR TITLE
Add MAQAMI Travel - Hotel & Flight Booking MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A curated list of **MCP servers** and **AI skills** for finance, trading, and cr
 
 **Community**
 - [Community Contributions](#community-contributions) 🆕
+- [MAQAMI Travel](https://github.com/negm17111995/mcp-server) - Hotel and flight booking MCP server with direct booking links for 249 countries.
 
 ---
 


### PR DESCRIPTION
Adding MAQAMI Travel to the list of MCP servers. It provides direct AI hotel and flight bookings across 249 countries.

Server: https://mcp.maqami.co
Repo: https://github.com/negm17111995/mcp-server