### PR TITLE
Add AgentServices — x402-paid crypto/market data APIs with MCP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ A curated list of **MCP servers** and **AI skills** for finance, trading, and cr
 | [CCXT MCP](https://github.com/Nayshins/mcp-server-ccxt) | Data from 20+ exchanges via CCXT | Free | ![GitHub stars](https://img.shields.io/github/stars/Nayshins/mcp-server-ccxt?style=flat) |
 | [Crypto Indicators MCP](https://github.com/kukapay/crypto-indicators-mcp) | Technical analysis indicators | Free | ![GitHub stars](https://img.shields.io/github/stars/kukapay/crypto-indicators-mcp?style=flat) |
 | [TradingView MCP](https://github.com/atilaahmettaner/tradingview-mcp) | Advanced market analysis, multi-exchange | Freemium | ![GitHub stars](https://img.shields.io/github/stars/atilaahmettaner/tradingview-mcp?style=flat) |
+| [AgentServices](https://github.com/vbkotecha/aiservices-api) | 54-service x402-paid crypto/market data API with 37 MCP tools | x402 ($0.01/call) | ![GitHub stars](https://img.shields.io/github/stars/vbkotecha/aiservices-api?style=flat) |
 | [AgentServices](https://agentservices.to) | 54+ crypto/market data APIs with x402 on-chain payments, 37 MCP tools, DeFi yields, on-chain whale tracking | x402 ($0.01/call) | — |
 
 ### Crypto Trading Execution

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ A curated list of **MCP servers** and **AI skills** for finance, trading, and cr
 | [CCXT MCP](https://github.com/Nayshins/mcp-server-ccxt) | Data from 20+ exchanges via CCXT | Free | ![GitHub stars](https://img.shields.io/github/stars/Nayshins/mcp-server-ccxt?style=flat) |
 | [Crypto Indicators MCP](https://github.com/kukapay/crypto-indicators-mcp) | Technical analysis indicators | Free | ![GitHub stars](https://img.shields.io/github/stars/kukapay/crypto-indicators-mcp?style=flat) |
 | [TradingView MCP](https://github.com/atilaahmettaner/tradingview-mcp) | Advanced market analysis, multi-exchange | Freemium | ![GitHub stars](https://img.shields.io/github/stars/atilaahmettaner/tradingview-mcp?style=flat) |
+| [AgentServices](https://agentservices.to) | 54+ crypto/market data APIs with x402 on-chain payments, 37 MCP tools, DeFi yields, on-chain whale tracking | x402 ($0.01/call) | — |
 
 ### Crypto Trading Execution
 


### PR DESCRIPTION
## AgentServices

**Website:** https://agentservices.to
**API:** https://api.agentservices.to
**MCP:** https://agentservices.to/mcp

AgentServices is a production x402-paid API marketplace for AI agents, offering:

- **54+ services** spanning crypto prices, technical indicators, DeFi yields, on-chain whale tracking, exchange flows, fear & greed index, gas prices, trending tokens, news, social sentiment, and market intelligence
- **37 MCP tools** via a remote MCP server (protocol 2026-07-28)
- **x402 payments** — pay-per-call with on-chain USDC settlement on Base ($0.01/call)
- **97 API paths**, 41 x402-paid endpoints

Listed on the official MCP Registry: `to.agentservices/agentservices` (v5.3.0)

### Pricing
x402 pay-per-call ($0.01/call, settled in USDC on Base)

Added to the **Crypto Data Providers** section.