### PR TITLE
Add BDE Score MCP server - quantitative stock analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ A curated list of **MCP servers** and **AI skills** for finance, trading, and cr
 | [TrendRadar](https://github.com/sansan0/TrendRadar) | AI sentiment monitoring, hot topic tracking | Free | ![GitHub stars](https://img.shields.io/github/stars/sansan0/TrendRadar?style=flat) |
 | [Finbrain MCP](https://github.com/ahmetsbilgin/finbrain-mcp) | Institutional-grade alternative data | Requires API key | ![GitHub stars](https://img.shields.io/github/stars/ahmetsbilgin/finbrain-mcp?style=flat) |
 | [Norman Finance MCP](https://github.com/norman-finance/norman-mcp-server) | Accounting, invoices, taxes | Requires credentials | ![GitHub stars](https://img.shields.io/github/stars/norman-finance/norman-mcp-server?style=flat) |
+| [BDE Score](https://github.com/hbhqq9/bde-score) | Multi-factor quantitative stock analysis MCP server (US/HK/CN A-share). Transparent 0-100 composite scores, EU AI Act Art.50 compliant | Free | ![stars](https://img.shields.io/github/stars/hbhqq9/bde-score?style=flat-square) |
 
 ---
 


### PR DESCRIPTION
Add BDE Score to Financial Intelligence section.

- Multi-factor quantitative stock analysis MCP server
- Markets: US, HK, CN A-share
- Transparent 0-100 composite scores
- EU AI Act Art.50 compliant
- Streamable HTTP MCP transport
- Listed on Official MCP Registry (io.github.hbhqq9/bde-score)
- GitHub: https://github.com/hbhqq9/bde-score