### PR TITLE
Add Predge Whale Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ A curated list of **MCP servers** and **AI skills** for finance, trading, and cr
 | Name | Description | Pricing | Stars | Contributor |
 |------|-------------|---------|-------|-------------|
 | [OpenBB MCP](https://github.com/OpenBB-finance/OpenBB) | OpenBB financial platform | Free | ![stars](https://img.shields.io/github/stars/OpenBB-finance/OpenBB?style=flat) | *[@MagnusS0](https://github.com/MagnusS0)* |
+| [Predge Whale Data](https://github.com/predgeAI/whale-data-mcp) | Outcome-verified Polymarket whale intelligence | Free (x402) | ![stars](https://img.shields.io/github/stars/predgeAI/whale-data-mcp?style=flat) | *[@predge-ai](https://github.com/predge-ai)* |
 
 ---
 


### PR DESCRIPTION
Adds **Predge** to the list — an outcome-verified Polymarket whale-intelligence MCP server for AI agents.

- Surfaces Polymarket trades ≥$10k, wallet leaderboards ranked on realized edge over market price, and smart-money consensus.
- Pay-per-call in USDC on Base via x402 (13 endpoints, $0.005–$0.03) — no accounts or API keys.
- npm: `@predge/whale-data-mcp` — `npx -y @predge/whale-data-mcp`
- In the official MCP Registry as `io.github.predgeAI/whale-data-mcp`.
- Repo: https://github.com/predgeAI/whale-data-mcp

One resource added at the bottom of the relevant category, following the existing entry format.
