### PR TITLE
Add Trends MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ A curated list of **MCP servers** and **AI skills** for finance, trading, and cr
 | [KOSPI/KOSDAQ MCP](https://github.com/dragon1086/kospi-kosdaq-stock-server) | Korean stock market data | Free | ![GitHub stars](https://img.shields.io/github/stars/dragon1086/kospi-kosdaq-stock-server?style=flat) |
 | [Yahoo Finance MCP](https://github.com/maxscheijen/mcp-yahoo-finance) | Yahoo Finance stock data | Free | ![GitHub stars](https://img.shields.io/github/stars/maxscheijen/mcp-yahoo-finance?style=flat) |
 | [HK Finance MCP](https://github.com/hkopenai/hk-finance-mcp-server) | Hong Kong stock market data | Free | ![GitHub stars](https://img.shields.io/github/stars/hkopenai/hk-finance-mcp-server?style=flat) |
+- [Trends MCP](https://github.com/trendsmcp-ai/Trends-MCP) - Freemium MCP/API for cross-platform trend and news-sentiment signals useful as alternative data.
 
 ### Trading Execution
 


### PR DESCRIPTION
Adds a listing for [Trends MCP](https://github.com/trendsmcp-ai/Trends-MCP) (https://trendsmcp.ai).

Live trend data MCP server and REST API across 25+ platforms (Google Search, YouTube, TikTok, Reddit, Amazon, Wikipedia, news sentiment, app downloads, npm, Steam, and more).

Public product links only. No secrets or credentials included.