### PR TITLE
Add Trends MCP — trend data API + MCP server (25+ sources)

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,3 +229,4 @@ BlockRun enables AI agents to make autonomous payments using x402 protocol. No A
 [![CC0](https://licensebuttons.net/p/zero/1.0/88x31.png)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 To the extent possible under law, [BlockRun](https://blockrun.ai) has waived all copyright and related rights to this work.
+- [Trends MCP](https://github.com/trendsmcp-ai/Trends-MCP) - Live trend data across 25+ platforms (Google, YouTube, TikTok, Reddit, Amazon, news sentiment, app downloads, more). MCP server + REST API. [Free tier](https://trendsmcp.ai) (100 req/mo).


### PR DESCRIPTION
## Summary
Adds [Trends MCP](https://github.com/trendsmcp-ai/Trends-MCP) — free-tier trend data API + MCP server across 25+ platforms.

- Site: https://trendsmcp.ai
- Docs: https://trendsmcp.ai/docs
- Free tier: 100 req/mo, no card

Insertion: `inserted_in:mcp`
