### PR TITLE
Add PnL Labs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ A curated list of **MCP servers** and **AI skills** for finance, trading, and cr
 | [Armor Crypto MCP](https://github.com/armorwallet/armor-crypto-mcp) | Swaps, DeFi, wallet management | Requires wallet | ![GitHub stars](https://img.shields.io/github/stars/armorwallet/armor-crypto-mcp?style=flat) |
 
 ### On-Chain Analytics
+- [PnL Labs](https://github.com/PnLlabs/pnllabs-mcp) - Trust & risk verdicts for AI trading agents on Solana: real realized-PnL wallet trust (not peak scores), wallet funding forensics, token safety, and trade cost. Paid per call via x402. ([site](https://pnllabs.com))
 
 | Name | Description | Pricing | Stars |
 |------|-------------|---------|-------|


### PR DESCRIPTION
Adds **PnL Labs** — trust & risk verdicts for AI trading agents on Solana via x402 (no keys). Real realized-PnL wallet trust (not peak scores), funding forensics, token safety, trade cost. MCP server + machine-first JSON.

https://pnllabs.com · https://github.com/PnLlabs/pnllabs-mcp