### PR TITLE
Add open-banking.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ A curated list of **MCP servers** and **AI skills** for finance, trading, and cr
 | [Ramp MCP](https://github.com/ramp-public/ramp_mcp) | Spend analytics via LLMs | Requires credentials | ![GitHub stars](https://img.shields.io/github/stars/ramp-public/ramp_mcp?style=flat) |
 | [Fewsats MCP](https://github.com/Fewsats/fewsats-mcp) | Bitcoin purchases for AI agents | Freemium | ![GitHub stars](https://img.shields.io/github/stars/Fewsats/fewsats-mcp?style=flat) |
 | [x402 Payment MCP](https://github.com/coinbase/x402) | HTTP-native payments for AI agents | Free (x402) | ![GitHub stars](https://img.shields.io/github/stars/coinbase/x402?style=flat) |
+| [open-banking.io](https://github.com/open-banking-io/clients) | Cert-free PSD2/open banking API with MCP | Paid API key | ![GitHub stars](https://img.shields.io/github/stars/open-banking-io/clients?style=flat) |
 
 ---
 


### PR DESCRIPTION
Adds **[open-banking.io](https://open-banking.io)** to the Payments & Banking section.

open-banking.io is a **cert-free PSD2/open banking API** for accessing EU/UK bank accounts, balances, and transactions. Unlike traditional PSD2 integrations, it requires **no eIDAS certificate** — you can connect to European banks with a simple API key at roughly €3/month. It now ships an MCP server so AI agents can query accounts and transactions directly.

MCP integration write-up: https://dev.to/johnfrandsen/open-banking-mcp-server-with-fastmcp-and-psd2-apis

Entry follows the existing table format: GitHub link (`open-banking-io/clients` — SDKs + `openbanking` CLI), concise description (<60 chars), valid pricing value (`Paid API key`), and a matching stars badge. Placed alongside the other banking/payment APIs in the Payments & Banking section.

**Affiliation disclosure:** I maintain open-banking.io.
