### PR TITLE
Add Pineify MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,3 +229,5 @@ BlockRun enables AI agents to make autonomous payments using x402 protocol. No A
 [![CC0](https://licensebuttons.net/p/zero/1.0/88x31.png)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 To the extent possible under law, [BlockRun](https://blockrun.ai) has waived all copyright and related rights to this work.
+
+| [Pineify MCP](https://github.com/pineifyapp/pineify-mcp) | Trading-code validation and market intelligence | Paid API key | ![GitHub stars](https://img.shields.io/github/stars/pineifyapp/pineify-mcp?style=flat) |


### PR DESCRIPTION
## Summary

Adds Pineify MCP to **Financial Intelligence**.

Pineify MCP is a remote, read-only server with 14 tools covering Pine Script, MQL5 and cTrader validation, stock research, technical analysis, options flow, dark-pool activity, congressional trades and event briefings.

- Transport: Streamable HTTP
- Authentication: Bearer token
- Pricing: Paid API key
- Trade execution: Not supported
- Repository: https://github.com/pineifyapp/pineify-mcp
- Documentation: https://pineify.app/mcp

Disclosure: This is an official Pineify team submission.