### PR TITLE
Add OptionsAhoy MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,12 @@ A curated list of **MCP servers** and **AI skills** for finance, trading, and cr
 |------|-------------|---------|-------|-------------|
 | [OpenBB MCP](https://github.com/OpenBB-finance/OpenBB) | OpenBB financial platform | Free | ![stars](https://img.shields.io/github/stars/OpenBB-finance/OpenBB?style=flat) | *[@MagnusS0](https://github.com/MagnusS0)* |
 
+### Personal Finance
+
+| Name | Description | Pricing | Stars | Contributor |
+|------|-------------|---------|-------|-------------|
+| [OptionsAhoy MCP](https://github.com/AlvisoOculus/optionsahoy-mcp) | Equity compensation tax optimizer: ISO, NSO, RSU, QSBS | Free | ![stars](https://img.shields.io/github/stars/AlvisoOculus/optionsahoy-mcp?style=flat) | *[@AlvisoOculus](https://github.com/AlvisoOculus)* |
+
 ---
 
 ## Skills


### PR DESCRIPTION
Adds OptionsAhoy MCP: an equity-compensation tax optimizer (incentive stock option (ISO) exercise schedules with alternative minimum tax (AMT), NSO, RSU sell-vs-hold and lot ordering, QSBS checks, concentration analysis, hedge pricing) with federal, 50-state, and DC tax math. MIT, free, works remotely at https://optionsahoy.com/mcp (Streamable HTTP, no API key) or self-hosted from the repo.

Placed under Community Contributions in a new Personal Finance subsection, using the 5-column community format from AGENTS.md. If you'd rather have it in the main Personal Finance table (4-column CONTRIBUTING.md format), happy to switch.