### PR TITLE
Add stipend

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ A curated list of **MCP servers** and **AI skills** for finance, trading, and cr
 | [Ramp MCP](https://github.com/ramp-public/ramp_mcp) | Spend analytics via LLMs | Requires credentials | ![GitHub stars](https://img.shields.io/github/stars/ramp-public/ramp_mcp?style=flat) |
 | [Fewsats MCP](https://github.com/Fewsats/fewsats-mcp) | Bitcoin purchases for AI agents | Freemium | ![GitHub stars](https://img.shields.io/github/stars/Fewsats/fewsats-mcp?style=flat) |
 | [x402 Payment MCP](https://github.com/coinbase/x402) | HTTP-native payments for AI agents | Free (x402) | ![GitHub stars](https://img.shields.io/github/stars/coinbase/x402?style=flat) |
+| [stipend](https://github.com/stipend-sh/stipend) | Non-custodial USDC wallet with code-enforced limits | Free (self-hosted) | ![GitHub stars](https://img.shields.io/github/stars/stipend-sh/stipend?style=flat) |
 
 ---
 


### PR DESCRIPTION
**What it does:** [stipend](https://github.com/stipend-sh/stipend) is a non-custodial USDC wallet on Base that an AI agent installs by itself. Per-transaction, per-day and per-counterparty caps plus a destination allowlist are enforced in code between the agent's decision and the signature, so no instruction in a context window can raise them. It ships an MCP server over stdio (`stipend mcp`) with 7 tools: `stipend_address`, `stipend_balance`, `stipend_check`, `stipend_pay`, `stipend_earnings`, `stipend_report`, `stipend_recover`.

**Category:** Payments & Banking.

**Format:** one row, four columns, matching the neighbouring rows. Description is 51 characters. Pricing is `Free (self-hosted)` — the software is free and runs locally; the only cost is gas on Base.

Python, Apache-2.0. It is **not audited** — worth saying plainly, since it holds keys.
