### PR TITLE
Add Edgrapi (SEC EDGAR MCP server) to Community Contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ A curated list of **MCP servers** and **AI skills** for finance, trading, and cr
 
 > 🙏 Thanks to these contributors who submitted their MCP servers!
 
+### Stock Market
+
+| Name | Description | Pricing | Stars | Contributor |
+|------|-------------|---------|-------|-------------|
+| [Edgrapi](https://github.com/paperandbeyond23-gif/edgrapi-mcp) | SEC EDGAR insider trades (Form 4), 8-Ks, 13F holdings & 13D/13G >5% stakes as clean JSON | Freemium | ![stars](https://img.shields.io/github/stars/paperandbeyond23-gif/edgrapi-mcp?style=flat) | *[@paperandbeyond23-gif](https://github.com/paperandbeyond23-gif)* |
+
 ### Cryptocurrency & Blockchain
 
 | Name | Description | Pricing | Stars | Contributor |


### PR DESCRIPTION
Adds Edgrapi to Community Contributions -> Stock Market.

Edgrapi is a hosted MCP server (plus REST API) for clean SEC EDGAR filings: insider trades (Form 4), 8-K events, 13F fund holdings (CUSIP-aggregated, diffed quarter-over-quarter), and 13D/13G >5% activist stakes, plus normalized fundamentals. 9 tools, streamable-http.

MCP endpoint: https://api.edgrapi.com/mcp
Site and docs: https://edgrapi.com
Pricing: Freemium (100 credits/mo free, no card)
Also listed in the Official MCP Registry (io.github.paperandbeyond23-gif/edgrapi-skills)

Checklist: finance/financial-data related, working GitHub link, accurate description and pricing, tested against the live endpoint.