### PR TITLE
Add Cue Data MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ A curated list of **MCP servers** and **AI skills** for finance, trading, and cr
 | [TrendRadar](https://github.com/sansan0/TrendRadar) | AI sentiment monitoring, hot topic tracking | Free | ![GitHub stars](https://img.shields.io/github/stars/sansan0/TrendRadar?style=flat) |
 | [Finbrain MCP](https://github.com/ahmetsbilgin/finbrain-mcp) | Institutional-grade alternative data | Requires API key | ![GitHub stars](https://img.shields.io/github/stars/ahmetsbilgin/finbrain-mcp?style=flat) |
 | [Norman Finance MCP](https://github.com/norman-finance/norman-mcp-server) | Accounting, invoices, taxes | Requires credentials | ![GitHub stars](https://img.shields.io/github/stars/norman-finance/norman-mcp-server?style=flat) |
+| [Cue Data MCP](https://github.com/sensedeal/cue-skills) | Cue Data MCP: macro, SEC EDGAR, IPO, sanctions, statutes | Requires API key | ![GitHub stars](https://img.shields.io/github/stars/sensedeal/cue-skills?style=flat) |
 
 ---
 


### PR DESCRIPTION
Adds **Cue Data MCP** to the **Financial Intelligence** section — Cue's public data MCP services (macro, SEC EDGAR, IPO, ESOP, buyback, sanctions, statutes, entity data, footnote/fact index, ~104 tools across 15 domains) exposed as streamable-http MCP endpoints. Pricing: **Requires API key** (free key + daily credits from https://cuecue.cn/hub/api-key).