### PR TITLE
Add Aperture Wallet Knowledge

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ A curated list of **MCP servers** and **AI skills** for finance, trading, and cr
 | [dexscreener-trending-mcp](https://github.com/kukapay/dexscreener-trending-mcp) | DexScreener trending tokens | Free | ![stars](https://img.shields.io/github/stars/kukapay/dexscreener-trending-mcp?style=flat) | *[@kukapay](https://github.com/kukapay)* |
 | [investor-agent](https://github.com/ferdousbhai/investor-agent) | MCP server for building an investor agent | Free | ![stars](https://img.shields.io/github/stars/ferdousbhai/investor-agent?style=flat) | *[@ferdousbhai](https://github.com/ferdousbhai)* |
 | [coincap-mcp](https://github.com/QuantGeekDev/coincap-mcp) | Access crypto data from CoinCap API | Free | ![stars](https://img.shields.io/github/stars/QuantGeekDev/coincap-mcp?style=flat) | *[@QuantGeekDev](https://github.com/QuantGeekDev)* |
+| [Aperture Wallet Knowledge](https://github.com/devdasx/aperture) | Read-only Aperture wallet knowledge for AI agents | Free | ![stars](https://img.shields.io/github/stars/devdasx/aperture?style=flat) | *[@devdasx](https://github.com/devdasx)* |
 
 ### Financial Intelligence
 


### PR DESCRIPTION
## Summary

Adds Aperture Wallet Knowledge to Community Contributions → Cryptocurrency & Blockchain.

Aperture publishes a vendor-maintained, no-auth Streamable HTTP MCP server for citation-ready wallet product, security, supported-mainnet, release, app-screen, safe-entry-point, and Journal knowledge. The server is intentionally read-only: it cannot connect to a wallet, access credentials or balances, sign, broadcast, or change state.

## Verification

- Public GitHub repository and README are live.
- Production endpoint `https://aperturex.io/mcp/` returns HTTP 200.
- Agent connection guide `https://aperturex.io/agents/` returns HTTP 200.
- Official MCP Registry identity: `io.aperturex/aperture-wallet-knowledge`.
- All new links return HTTP 200.
- Description is 49 characters, below the documented 60-character limit.
- `git diff --check` passes.
- Pricing is `Free`; no account, API key, or wallet connection is required.