### PR TITLE
Add Edgrapi to Data Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ A curated list of **MCP servers** and **AI skills** for finance, trading, and cr
 | [KOSPI/KOSDAQ MCP](https://github.com/dragon1086/kospi-kosdaq-stock-server) | Korean stock market data | Free | ![GitHub stars](https://img.shields.io/github/stars/dragon1086/kospi-kosdaq-stock-server?style=flat) |
 | [Yahoo Finance MCP](https://github.com/maxscheijen/mcp-yahoo-finance) | Yahoo Finance stock data | Free | ![GitHub stars](https://img.shields.io/github/stars/maxscheijen/mcp-yahoo-finance?style=flat) |
 | [HK Finance MCP](https://github.com/hkopenai/hk-finance-mcp-server) | Hong Kong stock market data | Free | ![GitHub stars](https://img.shields.io/github/stars/hkopenai/hk-finance-mcp-server?style=flat) |
+| [Edgrapi](https://github.com/paperandbeyond23-gif/edgrapi-skills) | SEC EDGAR insider trades with cluster-buy detection, 8-Ks, 13F holdings diffed QoQ, 13D/G stakes, XBRL, full-text search | Freemium | ![GitHub stars](https://img.shields.io/github/stars/paperandbeyond23-gif/edgrapi-skills?style=flat) |
 
 ### Trading Execution
 


### PR DESCRIPTION
Hosted MCP server and REST API for parsed SEC EDGAR data: Form 4 insider trades with cluster-buy detection, typed 8-K events, 13F fund holdings diffed quarter-over-quarter, 13D/13G >5% stakes, XBRL fundamentals and full-text search. Listed on the official MCP registry. Free tier, no card.