### PR TITLE
Add x402 Preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ A curated list of **MCP servers** and **AI skills** for finance, trading, and cr
 | [dexscreener-trending-mcp](https://github.com/kukapay/dexscreener-trending-mcp) | DexScreener trending tokens | Free | ![stars](https://img.shields.io/github/stars/kukapay/dexscreener-trending-mcp?style=flat) | *[@kukapay](https://github.com/kukapay)* |
 | [investor-agent](https://github.com/ferdousbhai/investor-agent) | MCP server for building an investor agent | Free | ![stars](https://img.shields.io/github/stars/ferdousbhai/investor-agent?style=flat) | *[@ferdousbhai](https://github.com/ferdousbhai)* |
 | [coincap-mcp](https://github.com/QuantGeekDev/coincap-mcp) | Access crypto data from CoinCap API | Free | ![stars](https://img.shields.io/github/stars/QuantGeekDev/coincap-mcp?style=flat) | *[@QuantGeekDev](https://github.com/QuantGeekDev)* |
+| [x402 Preflight](https://github.com/chico10117/basepay-readiness-service) | Preflight checks for x402 endpoints before payment | Freemium | ![stars](https://img.shields.io/github/stars/chico10117/basepay-readiness-service?style=flat) | *[@chico10117](https://github.com/chico10117)* |
 
 ### Financial Intelligence
 


### PR DESCRIPTION
Adds x402 Preflight to Community Contributions → Cryptocurrency & Blockchain.

The public Streamable HTTP MCP has a free inspection path and x402-paid audit/remediation tools. It performs bounded, read-only checks and never holds buyer keys, signs, or spends.

Verification:
- repository and badge links return HTTP 200
- public MCP tools/list returns three canonical tools
- paid audit returns HTTP 402 before execution
- description is under 60 characters
- git diff --check passes