### PR TITLE
Add Slacking MCP — SEC, FRED, Census, IRS, FDA, Treasury (75 tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ A curated list of **MCP servers** and **AI skills** for finance, trading, and cr
 | [Yahoo Finance MCP](https://github.com/maxscheijen/mcp-yahoo-finance) | Yahoo Finance stock data | Free | ![GitHub stars](https://img.shields.io/github/stars/maxscheijen/mcp-yahoo-finance?style=flat) |
 | [HK Finance MCP](https://github.com/hkopenai/hk-finance-mcp-server) | Hong Kong stock market data | Free | ![GitHub stars](https://img.shields.io/github/stars/hkopenai/hk-finance-mcp-server?style=flat) |
 | [Edgrapi](https://github.com/paperandbeyond23-gif/edgrapi-skills) | SEC EDGAR insider trades, 8-Ks, 13F/13D-G, XBRL, full-text search | Freemium | ![GitHub stars](https://img.shields.io/github/stars/paperandbeyond23-gif/edgrapi-skills?style=flat) |
+| [Slacking MCP](https://github.com/Th3Slack3r/slacking-mcp) | SEC, FRED, Census, IRS 990, FDA, Treasury — 75 tools | Freemium | ![GitHub stars](https://img.shields.io/github/stars/Th3Slack3r/slacking-mcp?style=flat) |
 
 ### Trading Execution
 


### PR DESCRIPTION
## Summary

Adds [Slacking MCP](https://github.com/Th3Slack3r/slacking-mcp) to Stock Market > Data Providers.

**75 tools** covering SEC EDGAR filings (10-K, 10-Q, 8-K, Form 4), FRED economic data, Census demographics, IRS 990 nonprofit financials, FDA health data (drugs, devices, recalls), US Treasury fiscal data, and UK Companies House.

### Verification

- **Live endpoint**: https://slacking.biz/mcp (GET + POST initialize → 200)
- **Official MCP Registry**: v1.2.1, active, isLatest=true
- **Glama**: claimed, 75 tools indexed
- **Listed on**: Smithery, MCPize, RapidAPI, MCP-Hive, mcpservers.org, ServerHub, LobeHub, mcprepository, MCP Market

### Entry

```
| [Slacking MCP](https://github.com/Th3Slack3r/slacking-mcp) | SEC, FRED, Census, IRS 990, FDA, Treasury — 75 tools | Freemium |
```

The server also covers global macro data (World Bank indicators, OECD statistics) and multi-country financial data beyond the US.