### PR TITLE
Add registry-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ A curated list of **MCP servers** and **AI skills** for finance, trading, and cr
 | [AlphaSMO](https://github.com/alphasmo/alphasmo-tools) | SEC 13F holdings, Form 4 insider trades, smart-money signals | Freemium | ![stars](https://img.shields.io/github/stars/alphasmo/alphasmo-tools?style=flat) | *[@alphasmo](https://github.com/alphasmo)* |
 | [GitDealFlow](https://github.com/kindrat86/mcp-deal-flow-signal) | Startup deal-flow signals from GitHub activity | Free | ![stars](https://img.shields.io/github/stars/kindrat86/mcp-deal-flow-signal?style=flat) | *[@kindrat86](https://github.com/kindrat86)* |
 | [Predge](https://github.com/predgeAI/whale-data-mcp) | Signed, outcome-verified trader-skill (edge) scores for Polymarket & Kalshi wallets | Pay-per-call (x402) | ![stars](https://img.shields.io/github/stars/predgeAI/whale-data-mcp?style=flat) | *[@predge-ai](https://github.com/predge-ai)* |
+| [registry-mcp](https://github.com/foretak/registry-mcp) | Company lookups: Norway, UK and Sweden registries — filings, no UBO/fraud screening | Free | ![GitHub stars](https://img.shields.io/github/stars/foretak/registry-mcp?style=flat) | *[@fargerod-dotcom](https://github.com/fargerod-dotcom)* |
 
 ### Personal Finance
 


### PR DESCRIPTION
Adds `registry-mcp` to Community Contributions → Financial Intelligence.

Company data for AI agents from three national business registries — Norway (Brønnøysundregistrene / Enhetsregisteret), the UK (Companies House) and Sweden (Bolagsverket): identity, status, address and filing data by national identifier. No UBO, sanctions or fraud screening — read-only register data only. Free for Norway; free registration keys unlock the UK and Sweden. Repo: https://github.com/foretak/registry-mcp (MIT). Official MCP Registry id `io.github.foretak/registry-mcp`.